### PR TITLE
Remove duplicate tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Other Starknet/Cairo related lists: [Other lists](#other-lists)
 - [`starklings-cairo1`](https://github.com/shramee/starklings-cairo1) – An interactive tutorial to get you up and running with Cairo and Starknet
 - [Reading Sierra: Starknet's secret sauce for Cairo 1.0](https://medium.com/yagi-fi/reading-sierra-starknets-secret-sauce-for-cairo-1-0-5bc73409e43c) – A tutorial for reading Sierra
 - [`HERDAO-cairo`](https://github.com/omarespejel/HERDAO-Cairo) - First smart contracts with Cairo and HER DAO
-- [Reading Sierra: Starknet's secret sauce for Cairo 1.0](https://medium.com/yagi-fi/reading-sierra-starknets-secret-sauce-for-cairo-1-0-5bc73409e43c) – A guide to reading Sierra syntax
 - [How to write ERC721 contracts with Cairo 1.0](https://blog.reddio.com/how-to-write-erc721-contracts-with-cairo-1/) – Guide to writing an ERC721 contract
 - [Under the hood of Cairo 1.0: Exploring Sierra](https://medium.com/nethermind-eth/under-the-hood-of-cairo-1-0-exploring-sierra-7f32808421f5) – A deep-dive into the purpose of Sierra
 


### PR DESCRIPTION
Hi,

There is a duplicate entry in the tutorial section for the article ___Reading Sierra: Starknet's secret sauce for Cairo 1.0___.

Thank you.