### PR TITLE
Add ONNX Cairo Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Other Starknet/Cairo related lists: [Other lists](#other-lists)
 - [`cairo_ml`](https://github.com/raphaelDkhn/cairo_ml) – Build neural network models in Cairo 1.0 to perform inference
 - [`corelib`](https://github.com/starkware-libs/cairo/tree/main/corelib/src) - Built in Cairo 1.0 standard library
 - [`quaireaux`](https://github.com/keep-starknet-strange/quaireaux) – Community maintained standard library for Cairo 1.0
+- [`onnx-cairo`](https://github.com/franalgaba/onnx-cairo) - ONNX Runtime in Cairo 1.0 for verifiable inference of trained ML models
 - [`neural-network-cairo`](https://github.com/franalgaba/neural-network-cairo) – Neural Network for MNIST in Cairo 1.0
 - [`cubit`](https://github.com/influenceth/cubit) – A fixed point math library in 64.64 representation built for Cairo 1.0
 - [`erc20.cairo`](https://github.com/starkware-libs/cairo/blob/main/crates/cairo-lang-starknet/test_data/erc20.cairo) – StarkWare's test ERC20 implementation


### PR DESCRIPTION
Hi,

Added to the list the unified `onnx-cairo` ONNX Cairo 1.0 Runtime for verifiable inference of trained ML models. This repository unifies the content of `cairo_ml` and `neural-network-cairo` into a standard framework to build ML models in the Starknet ecosystem.

Thanks.